### PR TITLE
Add function for sts get-caller-identity

### DIFF
--- a/aws/sts.go
+++ b/aws/sts.go
@@ -46,6 +46,18 @@ const (
 	UserTokenProviderName = "UserTokenProvider"
 )
 
+// GetCallerIdentity gets the caller's identity
+func (s *STS) GetCallerIdentity(input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+	output, err := s.Svc.GetCallerIdentity(input)
+	if error != nil {
+		return nil, errors.Wrap(err, "Could not get sts caller identity")
+	}
+	if output == nil {
+		return nil, errors.New("Nil output from aws when calling sts get-caller-identity")
+	}
+	return output, nil
+}
+
 // UserTokenProviderCache caches mfa tokens
 // Need this to json serialize/deserialize
 type UserTokenProviderCache struct {

--- a/aws/sts.go
+++ b/aws/sts.go
@@ -49,7 +49,7 @@ const (
 // GetCallerIdentity gets the caller's identity
 func (s *STS) GetCallerIdentity(input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
 	output, err := s.Svc.GetCallerIdentity(input)
-	if error != nil {
+	if err != nil {
 		return nil, errors.Wrap(err, "Could not get sts caller identity")
 	}
 	if output == nil {

--- a/aws/sts_mock.go
+++ b/aws/sts_mock.go
@@ -29,7 +29,7 @@ func (s *MockSTSSvc) GetSessionTokenWithContext(ctx aws.Context, in *sts.GetSess
 }
 
 // GetCallerIdentity mocks GetCallerIdentity
-func (s *MockSTSSvc) GetCallerIdentity(in *sts.GetCallerIdentityInput, ro ...request.Option) (*sts.GetCallerIdentityOutput, error) {
+func (s *MockSTSSvc) GetCallerIdentity(in *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
 	args := s.Called(in)
 	out := args.Get(0).(*sts.GetCallerIdentityOutput)
 	return out, args.Error(1)

--- a/aws/sts_mock.go
+++ b/aws/sts_mock.go
@@ -27,3 +27,10 @@ func (s *MockSTSSvc) GetSessionTokenWithContext(ctx aws.Context, in *sts.GetSess
 	out := args.Get(0).(*sts.GetSessionTokenOutput)
 	return out, args.Error(1)
 }
+
+// GetCallerIdentity mocks GetCallerIdentity
+func (s *MockSTSSvc) GetCallerIdentity(in *sts.GetCallerIdentityInput, ro ...request.Option) (*sts.GetCallerIdentityOutput, error) {
+	args := s.Called(in)
+	out := args.Get(0).(*sts.GetCallerIdentityOutput)
+	return out, args.Error(1)
+}

--- a/aws/sts_test.go
+++ b/aws/sts_test.go
@@ -85,7 +85,7 @@ func (ts *ProviderTestSuite) SetupTest() {
 	callerIdentity := &sts.GetCallerIdentityOutput{}
 	callerIdentity.SetAccount("my account id")
 	callerIdentity.SetArn("my user arn")
-	callerIdentity.SetUserID("my user id")
+	callerIdentity.SetUserId("my user id")
 	ts.mockSTS.On("GetCallerIdentity", mock.Anything).Return(callerIdentity, nil)
 
 	ts.pathsToRemove = []string{f.Name()}

--- a/aws/sts_test.go
+++ b/aws/sts_test.go
@@ -153,7 +153,7 @@ func (ts *ProviderTestSuite) TestGetCallerIdentity() {
 	a := assert.New(t)
 	input := &sts.GetCallerIdentityInput{}
 	res, err := ts.client.STS.GetCallerIdentity(input)
-	a.Equal(res.UserId, "my user id")
+	a.Equal(*res.UserId, "my user id")
 	a.Equal(err, nil)
 }
 

--- a/aws/sts_test.go
+++ b/aws/sts_test.go
@@ -154,6 +154,7 @@ func (ts *ProviderTestSuite) TestGetCallerIdentity() {
 	input := &sts.GetCallerIdentityInput{}
 	res, err := ts.client.STS.GetCallerIdentity(input)
 	a.Equal(res.UserId, "my user id")
+	a.Equal(err, nil)
 }
 
 func TestSTSProviderSuite(t *testing.T) {

--- a/aws/sts_test.go
+++ b/aws/sts_test.go
@@ -82,6 +82,12 @@ func (ts *ProviderTestSuite) SetupTest() {
 	ts.mockSTS.On("GetSessionTokenWithContext", mock.Anything).Return(token, nil)
 	ts.creds = creds
 
+	callerIdentity := &sts.GetCallerIdentityOutput{}
+	callerIdentity.SetAccount("my account id")
+	callerIdentity.SetArn("my user arn")
+	callerIdentity.SetUserID("my user id")
+	ts.mockSTS.On("GetCallerIdentity", mock.Anything).Return(callerIdentity, nil)
+
 	ts.pathsToRemove = []string{f.Name()}
 }
 
@@ -140,6 +146,14 @@ func (ts *ProviderTestSuite) TestCacheExpired() {
 	c, err := ts.provider.Retrieve()
 	a.Nil(err)
 	a.Equal(*ts.creds.AccessKeyId, c.AccessKeyID)
+}
+
+func (ts *ProviderTestSuite) TestGetCallerIdentity() {
+	t := ts.T()
+	a := assert.New(t)
+	input := &sts.GetCallerIdentityInput{}
+	res, err := ts.client.STS.GetCallerIdentity(input)
+	a.Equal(res.UserId, "my user id")
 }
 
 func TestSTSProviderSuite(t *testing.T) {


### PR DESCRIPTION
This is necessary for a future aws-okta PR that gets the user's username from their caller identity (rather than an IAM user username).