### PR TITLE
[feature] OIDC: Use refresh token if we can

### DIFF
--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -107,7 +107,7 @@ func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, err
 	if err == nil {
 		return newToken, nil
 	}
-	logrus.Debugf("failed to refresh token %s", err)
+	logrus.Warnf("failed to refresh token %s", err)
 
 	return c.Authenticate(ctx)
 }

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -119,7 +119,11 @@ func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error)
 	}
 	logrus.Info("attempting refresh token")
 
-	oauthToken := &oauth2.Token{}
+	oauthToken := &oauth2.Token{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		Expiry:       token.Expiry,
+	}
 	tokenSource := c.oauthConfig.TokenSource(ctx, oauthToken)
 
 	newOauth2Token, err := tokenSource.Token()

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -110,7 +110,7 @@ func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error)
 		logrus.Debug("nil refresh token, skipping refresh flow")
 		return nil, errors.New("cannot refresh nil token")
 	}
-	logrus.Info("attempting refresh token")
+	logrus.Debug("refresh token found, attempting refresh flow")
 
 	oauthToken := &oauth2.Token{
 		AccessToken:  token.AccessToken,

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -107,7 +107,7 @@ func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, err
 
 func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error) {
 	if token == nil {
-		logrus.Info("nil refresh token")
+		logrus.Debug("nil refresh token, skipping refresh flow")
 		return nil, errors.New("cannot refresh nil token")
 	}
 	logrus.Info("attempting refresh token")

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -100,7 +100,7 @@ func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, err
 	if err == nil {
 		return newToken, nil
 	}
-	logrus.Warnf("failed to refresh token %s, requesting new one", err)
+	logrus.Debugf("failed to refresh token %s, requesting new one", err)
 
 	return c.Authenticate(ctx)
 }

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -198,9 +198,6 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
 
 	c.server.Start(ctx, c, oauthMaterial)
 

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -114,8 +114,10 @@ func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, err
 
 func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error) {
 	if token == nil {
+		logrus.Info("nil refresh token")
 		return nil, errors.New("cannot refresh nil token")
 	}
+	logrus.Info("attempting refresh token")
 
 	oauthToken := &oauth2.Token{}
 	tokenSource := c.oauthConfig.TokenSource(ctx, oauthToken)

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -74,7 +74,7 @@ func (c *Client) idTokenFromOauth2Token(
 ) (*Claims, *oidc.IDToken, string, error) {
 	unverifiedIDToken, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
-		return nil, nil, "", fmt.Errorf("no id_token found in oauth2 token")
+		return nil, nil, "", errors.New("no id_token found in oauth2 token")
 	}
 
 	idToken, err := c.Verify(ctx, ourNonce, unverifiedIDToken)

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -107,7 +107,7 @@ func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, err
 	if err == nil {
 		return newToken, nil
 	}
-	logrus.Warnf("failed to refresh token %s", err)
+	logrus.Warnf("failed to refresh token %s, requesting new one", err)
 
 	return c.Authenticate(ctx)
 }
@@ -189,6 +189,7 @@ func (c *Client) Verify(ctx context.Context, rawIDToken string) (*oidc.IDToken, 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not verify id token")
 	}
+	logrus.Infof("their nonce: %s, our nonce: %s", idToken.Nonce, c.oauthMaterial.Nonce)
 	if !c.bytesAreEqual([]byte(idToken.Nonce), c.oauthMaterial.NonceBytes) {
 		return nil, errors.Errorf("nonce does not match")
 	}

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -86,7 +86,7 @@ func (c *Client) idTokenFromOauth2Token(
 
 	idToken, err := c.Verify(ctx, unverifiedIDToken)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("could not verify id token")
+		return nil, nil, "", errors.Wrap(err, "could not verify id token")
 	}
 
 	verifiedIDToken := unverifiedIDToken // now is verified
@@ -94,7 +94,7 @@ func (c *Client) idTokenFromOauth2Token(
 
 	err = idToken.Claims(claims)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("could not verify claims")
+		return nil, nil, "", errors.Wrap(err, "could not verify claims")
 	}
 	return claims, idToken, verifiedIDToken, nil
 }

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -198,7 +198,6 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 		return nil, err
 	}
 
-
 	c.server.Start(ctx, c, oauthMaterial)
 
 	err = browser.OpenURL(c.GetAuthCodeURL(oauthMaterial))

--- a/oidc_cli/client/client_test.go
+++ b/oidc_cli/client/client_test.go
@@ -12,14 +12,12 @@ func TestValidateState(t *testing.T) {
 	material, err := newOauthMaterial()
 	r.NoError(err)
 
-	c := &Client{
-		oauthMaterial: material,
-	}
+	c := &Client{}
 
-	err = c.ValidateState("definitely doesn't match")
+	err = c.ValidateState(material.StateBytes, []byte("definitely doesn't match"))
 	r.Error(err)
 
 	// matches, send the same value
-	err = c.ValidateState(c.oauthMaterial.State)
+	err = c.ValidateState(material.StateBytes, material.StateBytes)
 	r.NoError(err)
 }

--- a/oidc_cli/client/server.go
+++ b/oidc_cli/client/server.go
@@ -108,7 +108,7 @@ func (s *server) Start(ctx context.Context, oidcClient *Client, oauthMaterial *o
 			return
 		}
 
-		claims, _, verifiedIDToken, err := oidcClient.idTokenFromOauth2Token(ctx, oauth2Token, oauthMaterial.NonceBytes)
+		claims, idToken, verifiedIDToken, err := oidcClient.idTokenFromOauth2Token(ctx, oauth2Token, oauthMaterial.NonceBytes)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			s.err <- errors.Wrap(err, "could not verify ID token")
@@ -122,8 +122,7 @@ func (s *server) Start(ctx context.Context, oidcClient *Client, oauthMaterial *o
 		}
 
 		s.result <- &Token{
-			// Expiry:       idToken.Expiry,
-			Expiry:       time.Now().Add(-24 * time.Hour),
+			Expiry:       idToken.Expiry,
 			IDToken:      verifiedIDToken,
 			AccessToken:  oauth2Token.AccessToken,
 			RefreshToken: oauth2Token.RefreshToken,

--- a/oidc_cli/client/server.go
+++ b/oidc_cli/client/server.go
@@ -105,7 +105,7 @@ func (s *server) Start(ctx context.Context, oidcClient *Client) {
 			return
 		}
 
-		claims, idToken, verifiedIDToken, err := oidcClient.idTokenFromOauth2Token(ctx, oauth2Token)
+		claims, _, verifiedIDToken, err := oidcClient.idTokenFromOauth2Token(ctx, oauth2Token)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			s.err <- errors.Wrap(err, "could not verify ID token")
@@ -119,7 +119,8 @@ func (s *server) Start(ctx context.Context, oidcClient *Client) {
 		}
 
 		s.result <- &Token{
-			Expiry:       idToken.Expiry,
+			// Expiry:       idToken.Expiry,
+			Expiry:       time.Now().Add(-1 * time.Minute),
 			IDToken:      verifiedIDToken,
 			AccessToken:  oauth2Token.AccessToken,
 			RefreshToken: oauth2Token.RefreshToken,

--- a/oidc_cli/client/server.go
+++ b/oidc_cli/client/server.go
@@ -120,7 +120,7 @@ func (s *server) Start(ctx context.Context, oidcClient *Client) {
 
 		s.result <- &Token{
 			// Expiry:       idToken.Expiry,
-			Expiry:       time.Now().Add(-1 * time.Minute),
+			Expiry:       time.Now().Add(-24 * time.Hour),
 			IDToken:      verifiedIDToken,
 			AccessToken:  oauth2Token.AccessToken,
 			RefreshToken: oauth2Token.RefreshToken,


### PR DESCRIPTION
Had to do a bit of a refactor regarding the nonces, state, code verifier to get this to work. Attempt to use the refresh token if we have one. If refresh fails, fall back to authorization code flow. 