### PR TITLE
crohacz/print-browser-opening-warning

### DIFF
--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -200,14 +200,13 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 	}
 
 	c.server.Start(ctx, c, oauthMaterial)
-
-    fmt.Fprintf(os.Stderr, "Opening browser in order to authenticate with Okta... hold on a brief second\n")
+    fmt.Fprintf(os.Stderr, "Opening browser in order to authenticate with Okta, hold on a brief second...\n")
     time.Sleep(2 * time.Second)
 
 	err = browser.OpenURL(c.GetAuthCodeURL(oauthMaterial))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not open browser")
 	}
-
+    fmt.Fprintf(os.Stderr, "Success!\n")
 	return c.server.Wait(ctx)
 }

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
-
+    "time"
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
@@ -199,6 +199,9 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 	}
 
 	c.server.Start(ctx, c, oauthMaterial)
+
+    fmt.Printf("Opening browser to communicate with Okta... hold on a second")
+    time.Sleep(2 * time.Second)
 
 	err = browser.OpenURL(c.GetAuthCodeURL(oauthMaterial))
 	if err != nil {

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -201,7 +201,7 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 
 	c.server.Start(ctx, c, oauthMaterial)
 
-    fmt.Fprintf(os.Stderr, "Opening browser to communicate with Okta... hold on a second")
+    fmt.Fprintf(os.Stderr, "Opening browser in order to authenticate with Okta... hold on a brief second\n")
     time.Sleep(2 * time.Second)
 
 	err = browser.OpenURL(c.GetAuthCodeURL(oauthMaterial))

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
+    "os"
     "time"
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/browser"
@@ -200,7 +201,7 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 
 	c.server.Start(ctx, c, oauthMaterial)
 
-    fmt.Printf("Opening browser to communicate with Okta... hold on a second")
+    fmt.Printf(os.Stderr, "Opening browser to communicate with Okta... hold on a second")
     time.Sleep(2 * time.Second)
 
 	err = browser.OpenURL(c.GetAuthCodeURL(oauthMaterial))

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -201,7 +201,7 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 
 	c.server.Start(ctx, c, oauthMaterial)
 
-    fmt.Printf(os.Stderr, "Opening browser to communicate with Okta... hold on a second")
+    fmt.Fprintf(os.Stderr, "Opening browser to communicate with Okta... hold on a second")
     time.Sleep(2 * time.Second)
 
 	err = browser.OpenURL(c.GetAuthCodeURL(oauthMaterial))

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -206,7 +206,8 @@ func (c *Client) Authenticate(ctx context.Context) (*Token, error) {
 	err = browser.OpenURL(c.GetAuthCodeURL(oauthMaterial))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not open browser")
-	}
-    fmt.Fprintf(os.Stderr, "Success!\n")
+	} else {
+        fmt.Fprintf(os.Stderr, "Successfully authenticated!\n")
+    }
 	return c.server.Wait(ctx)
 }


### PR DESCRIPTION
Write a notification to stderr that we are opening the browser in order to authenticate the user. Sleep 2 seconds before we do this so that the user actually has time to digest the message printed to the console. Once we are finished authenticated and there is no error received, print a success message to the console as well.