### PR TITLE
[feature] Improve oidc pid locking

### DIFF
--- a/oidc_cli/cache/cache.go
+++ b/oidc_cli/cache/cache.go
@@ -2,9 +2,13 @@ package cache
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"time"
 
 	client "github.com/chanzuckerberg/go-misc/oidc_cli/client"
 	"github.com/chanzuckerberg/go-misc/oidc_cli/storage"
+	"github.com/chanzuckerberg/go-misc/pidlock"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -12,6 +16,7 @@ import (
 // Cache to cache credentials
 type Cache struct {
 	storage storage.Storage
+	lock    *pidlock.Lock
 
 	refreshToken func(context.Context, *client.Token) (*client.Token, error)
 }
@@ -20,33 +25,61 @@ type Cache struct {
 func NewCache(
 	storage storage.Storage,
 	refreshToken func(context.Context, *client.Token) (*client.Token, error),
+	lock *pidlock.Lock,
 ) *Cache {
 	return &Cache{
 		storage:      storage,
 		refreshToken: refreshToken,
+		lock:         lock,
 	}
 }
 
 // Read will attempt to read a token from the cache
 //      if not present or expired, will refresh
 func (c *Cache) Read(ctx context.Context) (*client.Token, error) {
-	cached, err := c.storage.Read(ctx)
+	// If we have a fresh token, use it
+	cachedToken, err := c.readFromStorage(ctx)
 	if err != nil {
 		return nil, err
 	}
-	cachedToken, err := client.TokenFromString(cached)
-	if err != nil {
-		logrus.Debugf("error fetching stored token: %s", err)
-		err = c.storage.Delete(ctx) // can't read it, so attempt to purge it
-		if err != nil {
-			logrus.Debugf("error clearing token from storage: %s", err)
-		}
-	}
-
-	if cachedToken.IsFresh() {
+	if cachedToken != nil {
 		return cachedToken, nil
 	}
 
+	// otherwise, try refreshing
+	return c.refresh(ctx, cachedToken)
+}
+
+func (c *Cache) refresh(ctx context.Context, cachedToken *client.Token) (*client.Token, error) {
+	f, err := os.OpenFile("/tmp/oidc-lock-time", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	start := time.Now()
+	err = c.lock.Lock()
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		c.lock.Unlock()                                                      //nolint: errcheck
+		f.WriteString(fmt.Sprintf("%d\n", time.Since(start).Milliseconds())) //nolint: errcheck
+	}()
+
+	// acquire lock, try reading from cache again just in case
+	// someone else got here first
+	cachedToken, err = c.readFromStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if cachedToken != nil {
+		return cachedToken, nil
+	}
+
+	// ok, at this point we have the lock and there are no good tokens around
+	// fetch a new one and save it
 	token, err := c.refreshToken(ctx, cachedToken)
 	if err != nil {
 		return nil, err
@@ -67,4 +100,23 @@ func (c *Cache) Read(ctx context.Context) (*client.Token, error) {
 	}
 
 	return token, nil
+}
+
+func (c *Cache) readFromStorage(ctx context.Context) (*client.Token, error) {
+	cached, err := c.storage.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cachedToken, err := client.TokenFromString(cached)
+	if err != nil {
+		logrus.Debugf("error fetching stored token: %s", err)
+		err = c.storage.Delete(ctx) // can't read it, so attempt to purge it
+		if err != nil {
+			logrus.Debugf("error clearing token from storage: %s", err)
+		}
+	}
+	if cachedToken.IsFresh() {
+		return cachedToken, nil
+	}
+	return nil, nil
 }

--- a/oidc_cli/cache/cache.go
+++ b/oidc_cli/cache/cache.go
@@ -48,7 +48,7 @@ func (c *Cache) Read(ctx context.Context) (*client.Token, error) {
 }
 
 func (c *Cache) refresh(ctx context.Context, cachedToken *client.Token) (*client.Token, error) {
-	err = c.lock.Lock()
+	err := c.lock.Lock()
 	if err != nil {
 		return nil, err
 	}

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -2,6 +2,8 @@ package oidc
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/chanzuckerberg/go-misc/oidc_cli/cache"
@@ -18,6 +20,14 @@ const (
 // GetToken gets an oidc token.
 // It handles caching with a default cache and keyring storage.
 func GetToken(ctx context.Context, clientID string, issuerURL string) (*client.Token, error) {
+	f, err := os.OpenFile("/tmp/oidc-lock-time", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	start := time.Now()
+	defer f.WriteString(fmt.Sprintf("%d\n", time.Since(start).Milliseconds())) //nolint: errcheck
+
 	fileLock, err := pidlock.NewLock(lockFilePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create lock")

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -24,15 +25,11 @@ func GetToken(ctx context.Context, clientID string, issuerURL string) (*client.T
 		return nil, errors.Wrap(err, "unable to create lock")
 	}
 
-	f, err := os.OpenFile("/tmp/oidc-lock", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile("/tmp/oidc-lock-time", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-
-	if _, err := f.WriteString("text to append\n"); err != nil {
-		return nil, err
-	}
 
 	start := time.Now()
 
@@ -41,8 +38,8 @@ func GetToken(ctx context.Context, clientID string, issuerURL string) (*client.T
 		return nil, errors.Wrap(err, "unable to lock")
 	}
 	defer func() {
-		fileLock.Unlock()                         //nolint: errcheck
-		f.WriteString(time.Since(start).String()) //nolint: errcheck
+		fileLock.Unlock()                                                    //nolint: errcheck
+		f.WriteString(fmt.Sprintf("%d\n", time.Since(start).Milliseconds())) //nolint: errcheck
 	}()
 
 	conf := &client.Config{

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -2,8 +2,6 @@ package oidc
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/chanzuckerberg/go-misc/oidc_cli/cache"
@@ -20,14 +18,6 @@ const (
 // GetToken gets an oidc token.
 // It handles caching with a default cache and keyring storage.
 func GetToken(ctx context.Context, clientID string, issuerURL string) (*client.Token, error) {
-	f, err := os.OpenFile("/tmp/oidc-lock-time", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	start := time.Now()
-	defer f.WriteString(fmt.Sprintf("%d\n", time.Since(start).Milliseconds())) //nolint: errcheck
-
 	fileLock, err := pidlock.NewLock(lockFilePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create lock")


### PR DESCRIPTION
Instead of acquiring an exclusive lock on each invocation of oidc clients, we only do it when we need to refresh tokens. This significantly speeds up code that doesn't efficiently re-use session/credentials (such as terraform).