### PR TITLE
[fix] Fix OIDC client refresh flow

### DIFF
--- a/oidc_cli/cache/cache.go
+++ b/oidc_cli/cache/cache.go
@@ -35,34 +35,34 @@ func NewCache(
 //      if not present or expired, will refresh
 func (c *Cache) Read(ctx context.Context) (*client.Token, error) {
 	// If we have a fresh token, use it
-	cachedToken, err := c.readFromStorage(ctx)
+	_, err := c.readFromStorage(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if cachedToken != nil {
-		return cachedToken, nil
-	}
+	// if cachedToken != nil {
+	// return cachedToken, nil
+	// }
 
 	// otherwise, try refreshing
-	return c.refresh(ctx, cachedToken)
+	return c.refresh(ctx)
 }
 
-func (c *Cache) refresh(ctx context.Context, cachedToken *client.Token) (*client.Token, error) {
+func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	err := c.lock.Lock()
 	if err != nil {
 		return nil, err
 	}
-	defer c.lock.Unlock()
+	defer c.lock.Unlock() //nolint:errcheck
 
 	// acquire lock, try reading from cache again just in case
 	// someone else got here first
-	cachedToken, err = c.readFromStorage(ctx)
+	cachedToken, err := c.readFromStorage(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if cachedToken != nil {
-		return cachedToken, nil
-	}
+	// if cachedToken != nil {
+	// return cachedToken, nil
+	// }
 
 	// ok, at this point we have the lock and there are no good tokens around
 	// fetch a new one and save it

--- a/oidc_cli/cache/cache.go
+++ b/oidc_cli/cache/cache.go
@@ -34,14 +34,14 @@ func NewCache(
 // Read will attempt to read a token from the cache
 //      if not present or expired, will refresh
 func (c *Cache) Read(ctx context.Context) (*client.Token, error) {
-	// If we have a fresh token, use it
-	_, err := c.readFromStorage(ctx)
+	cachedToken, err := c.readFromStorage(ctx)
 	if err != nil {
 		return nil, err
 	}
-	// if cachedToken != nil {
-	// return cachedToken, nil
-	// }
+	// if we have a valid token, use it
+	if cachedToken.IsFresh() {
+		return cachedToken, nil
+	}
 
 	// otherwise, try refreshing
 	return c.refresh(ctx)
@@ -60,9 +60,10 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	// if cachedToken != nil {
-	// return cachedToken, nil
-	// }
+	// if we have a valid token, use it
+	if cachedToken.IsFresh() {
+		return cachedToken, nil
+	}
 
 	// ok, at this point we have the lock and there are no good tokens around
 	// fetch a new one and save it
@@ -71,15 +72,16 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 		return nil, err
 	}
 
-	if token == nil {
-		return nil, errors.New("nil token returned")
+	// check the new token is good to use
+	if !token.IsFresh() {
+		return nil, errors.New("invalid token fetched")
 	}
 
+	// save token to storage
 	strToken, err := token.Marshal()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to marshall token")
 	}
-
 	err = c.storage.Set(ctx, strToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to cache the strToken")
@@ -88,6 +90,8 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	return token, nil
 }
 
+// reads token from storage, potentially returning a nil/expired token
+// users must call IsFresh to check token validty
 func (c *Cache) readFromStorage(ctx context.Context) (*client.Token, error) {
 	cached, err := c.storage.Read(ctx)
 	if err != nil {
@@ -95,14 +99,11 @@ func (c *Cache) readFromStorage(ctx context.Context) (*client.Token, error) {
 	}
 	cachedToken, err := client.TokenFromString(cached)
 	if err != nil {
-		logrus.Debugf("error fetching stored token: %s", err)
+		logrus.WithError(err).Debug("error fetching stored token")
 		err = c.storage.Delete(ctx) // can't read it, so attempt to purge it
 		if err != nil {
-			logrus.Debugf("error clearing token from storage: %s", err)
+			logrus.WithError(err).Debug("error clearing token from storage")
 		}
 	}
-	if cachedToken.IsFresh() {
-		return cachedToken, nil
-	}
-	return nil, nil
+	return cachedToken, nil
 }

--- a/oidc_cli/cache/cache_test.go
+++ b/oidc_cli/cache/cache_test.go
@@ -39,7 +39,8 @@ func TestNewCache(t *testing.T) {
 	r.NoError(err)
 
 	refresh := func(ctx context.Context, c *client.Token) (*client.Token, error) {
-		return &client.Token{IDToken: u.String()}, nil
+		// returns a "valid" token
+		return &client.Token{IDToken: u.String(), Expiry: time.Now().Add(time.Hour)}, nil
 	}
 
 	c := NewCache(s, refresh, fileLock)
@@ -65,7 +66,8 @@ func TestCorruptedCache(t *testing.T) {
 	r.NoError(err)
 
 	refresh := func(ctx context.Context, c *client.Token) (*client.Token, error) {
-		return &client.Token{IDToken: u.String()}, nil
+		// returns a "fresh" token
+		return &client.Token{IDToken: u.String(), Expiry: time.Now().Add(time.Hour)}, nil
 	}
 
 	c := NewCache(s, refresh, fileLock)

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -140,6 +140,8 @@ func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error)
 		return nil, err
 	}
 
+	logrus.Info("refresh worked!")
+
 	return &Token{
 		Version: token.Version,
 		Expiry:  idToken.Expiry,

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -104,7 +104,7 @@ func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, err
 	if err == nil {
 		return newToken, nil
 	}
-	logrus.Debugf("failed to refresh token %s, requesting new one", err)
+	logrus.WithError(err).Error("failed to refresh token, requesting new one")
 
 	return c.Authenticate(ctx)
 }

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -98,6 +98,7 @@ func (c *Client) idTokenFromOauth2Token(
 
 // RefreshToken will fetch a new token
 func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, error) {
+	logrus.Warnf("refresh scopes: %#v", c.oauthConfig.Scopes)
 	newToken, err := c.refreshToken(ctx, oldToken)
 	// if we could refresh successfully, do so.
 	// otherwise try a new token
@@ -128,8 +129,13 @@ func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error)
 		return nil, errors.Wrap(err, "could not refresh token")
 	}
 
-	// We don't have a nonce in this flow since we're refreshing our refresh token -- auth already happened
-	claims, idToken, verifiedIDToken, err := c.idTokenFromOauth2Token(ctx, newOauth2Token, []byte{})
+	// We don't have a nonce in this flow since we're refreshing
+	//    our refresh token -- auth already happened
+	zeroNonce := []byte{}
+	claims, idToken, verifiedIDToken, err := c.idTokenFromOauth2Token(
+		ctx,
+		newOauth2Token,
+		zeroNonce)
 	if err != nil {
 		return nil, err
 	}

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -98,14 +98,15 @@ func (c *Client) idTokenFromOauth2Token(
 
 // RefreshToken will fetch a new token
 func (c *Client) RefreshToken(ctx context.Context, oldToken *Token) (*Token, error) {
-	logrus.Warnf("refresh scopes: %#v", c.oauthConfig.Scopes)
+	logrus.Debugf("refresh scopes: %#v", c.oauthConfig.Scopes)
+
 	newToken, err := c.refreshToken(ctx, oldToken)
 	// if we could refresh successfully, do so.
 	// otherwise try a new token
 	if err == nil {
 		return newToken, nil
 	}
-	logrus.WithError(err).Error("failed to refresh token, requesting new one")
+	logrus.WithError(err).Debug("failed to refresh token, requesting new one")
 
 	return c.Authenticate(ctx)
 }
@@ -139,8 +140,7 @@ func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error)
 	if err != nil {
 		return nil, err
 	}
-
-	logrus.Info("refresh worked!")
+	logrus.Debug("refresh successful")
 
 	return &Token{
 		Version: token.Version,

--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -118,10 +118,10 @@ func (c *Client) refreshToken(ctx context.Context, token *Token) (*Token, error)
 	logrus.Debug("refresh token found, attempting refresh flow")
 
 	oauthToken := &oauth2.Token{
-		AccessToken:  token.AccessToken,
 		RefreshToken: token.RefreshToken,
 		Expiry:       token.Expiry,
 	}
+
 	tokenSource := c.oauthConfig.TokenSource(ctx, oauthToken)
 
 	newOauth2Token, err := tokenSource.Token()


### PR DESCRIPTION
Also added some more debug statements and did a bit of refactoring to clear dead code.

2 Issues:
- we were always returning a nil token from the cache when expired (instead of returning the refresh token). we instead return the token and defer checking token validity to the cache layer.
- we don't pass the access token to the refresh flow, instead just send over the refresh token.