### PR TITLE
[feature] Add lambda to process eks logs from cloudwatch

### DIFF
--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -3,7 +3,7 @@ S3_PREFIX = go-misc/lambdas/${DATE}
 S3_BUCKET ?= shared-infra-prod-assets
 AWS_PROFILE ?= czi-si
 
-publish: publish-cloudwatch_to_s3 publish-cloudwatch_to_honeycomb publish-flow_to_s3 publish-github_to_firehose publish-unfurl_cloudtrail
+publish: publish-cloudwatch_to_s3 publish-cloudwatch_to_honeycomb publish-flow_to_s3 publish-github_to_firehose publish-unfurl_cloudtrail publish-cloudwatch_eks_to_s3
 
 clean-cloudwatch_to_s3:
 	$(call clean,cloudwatch_to_s3.zip)
@@ -13,6 +13,15 @@ package-cloudwatch_to_s3: clean-cloudwatch_to_s3
 
 publish-cloudwatch_to_s3: package-cloudwatch_to_s3
 	$(call publish,cloudwatch_to_s3.zip)
+
+clean-cloudwatch_eks_to_s3:
+	$(call clean,cloudwatch_eks_to_s3.zip)
+
+package-cloudwatch_eks_to_s3: clean-cloudwatch_eks_to_s3
+	$(call package,eks_s3/cloudwatch_eks_to_s3.go,cloudwatch_eks_to_s3.zip)
+
+publish-cloudwatch_eks_to_s3: package-cloudwatch_eks_to_s3
+	$(call publish,cloudwatch_eks_to_s3.zip)
 
 clean-cloudwatch_to_honeycomb:
 	$(call clean,cloudwatch_to_honeycomb.zip)

--- a/lambda/eks_s3/cloudwatch_eks_to_s3.go
+++ b/lambda/eks_s3/cloudwatch_eks_to_s3.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	dataMessage = "DATA_MESSAGE"
+	// EKS logs will have loggroup starting with /aws/eks/<cluster-name>/cluster
+	eksLogGroupPrefix = "/aws/eks/"
+)
+
+type augmentedLogEvent struct {
+	events.CloudwatchLogsLogEvent
+	Owner     string `json:"owner,omitempty"`
+	LogGroup  string `json:"logGroup,omitempty"`
+	LogStream string `json:"logStream,omitempty"`
+}
+
+func processRecord(record events.KinesisFirehoseEventRecord) (response events.KinesisFirehoseResponseRecord, err error) {
+	response.Data = record.Data
+	response.RecordID = record.RecordID
+	logrus.Infof("Processing record %s", record.RecordID)
+
+	gr, err := gzip.NewReader(bytes.NewBuffer(record.Data))
+	if err != nil {
+		response.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+		return
+	}
+	defer gr.Close()
+
+	parsed := &events.CloudwatchLogsData{}
+	data, err := ioutil.ReadAll(gr)
+	if err != nil {
+		response.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+		return
+	}
+
+	err = json.Unmarshal(data, parsed)
+	if err != nil {
+		response.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+		return
+	}
+
+	if parsed.MessageType != dataMessage {
+		response.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+		return
+	}
+	messages := bytes.NewBuffer(nil)
+	b := []byte{} //nolint
+
+	// Set some common stuff
+	augmented := augmentedLogEvent{}
+	augmented.Owner = parsed.Owner
+	augmented.LogGroup = parsed.LogGroup
+	augmented.LogStream = parsed.LogStream
+
+	// Process only EKS records and drop the rest.
+	if !strings.HasPrefix(augmented.LogGroup, eksLogGroupPrefix) {
+		response.Result = events.KinesisFirehoseTransformedStateDropped
+		return
+	}
+
+	for _, logEvent := range parsed.LogEvents {
+		// update the contents
+		augmented.CloudwatchLogsLogEvent = logEvent
+		b, err = json.Marshal(augmented)
+		if err != nil {
+			response.Data = messages.Bytes()
+			response.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+			return
+		}
+		_, err = messages.Write(b)
+		if err != nil {
+			response.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+			return
+		}
+		_, err = messages.WriteRune('\n')
+		if err != nil {
+			response.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+			return
+		}
+	}
+	response.Data = messages.Bytes()
+	response.Result = events.KinesisFirehoseTransformedStateOk
+	logrus.Infof("Successfully parsed %d messages in recordID %s", len(parsed.LogEvents), record.RecordID)
+	return
+}
+
+// HandleRequest handles a kinesis event request
+func HandleRequest(ctx context.Context, kinesisEvent events.KinesisFirehoseEvent) (events.KinesisFirehoseResponse, error) {
+	response := events.KinesisFirehoseResponse{
+		Records: []events.KinesisFirehoseResponseRecord{},
+	}
+	logrus.Infof("Received %d kinesis records", len(kinesisEvent.Records))
+
+	for _, record := range kinesisEvent.Records {
+		record, err := processRecord(record)
+		if err != nil {
+			logrus.WithError(err).Error("Error processing records")
+			return response, err
+		}
+
+		response.Records = append(response.Records, record)
+	}
+	logrus.Info("Success")
+	return response, nil
+}
+
+func main() {
+	logrus.Info("Processing started")
+	lambda.Start(HandleRequest)
+}

--- a/lambda/eks_s3/cloudwatch_eks_to_s3_test.go
+++ b/lambda/eks_s3/cloudwatch_eks_to_s3_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
@@ -11,71 +10,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestS3ProcessRecordOK(t *testing.T) {
-	a := assert.New(t)
-
-	in := events.KinesisFirehoseEventRecord{
-		RecordID: "AAA",
-		Data:     []byte{},
-	}
-
-	data := events.CloudwatchLogsData{
-		Owner:       "an owner",
-		LogGroup:    "/aws/eks/some-cluster-name/cluster",
-		LogStream:   "a log stream",
-		MessageType: dataMessage,
-		LogEvents: []events.CloudwatchLogsLogEvent{
-			{
-				ID:        "asfd",
-				Message:   "asfd",
-				Timestamp: 123123,
-			},
-		},
-	}
-
-	b, err := json.Marshal(data)
-	a.Nil(err)
-
-	compressed := bytes.NewBuffer(nil)
-	g := gzip.NewWriter(compressed)
-	_, err = g.Write(b)
-	a.Nil(err)
-	err = g.Close()
-	a.Nil(err)
-	in.Data = compressed.Bytes()
-
-	out, err := processRecord(in)
-	a.Nil(err)
-
-	a.Equal(out.RecordID, in.RecordID)
-	a.Equal(out.Result, events.KinesisFirehoseTransformedStateOk)
-
-	r := bufio.NewReader(bytes.NewBuffer(out.Data))
-
-	l, _, err := r.ReadLine()
-	a.Nil(err)
-
-	log := &augmentedLogEvent{}
-	err = json.Unmarshal(l, log)
-	a.Nil(err)
-
-	a.Equal(log.LogGroup, data.LogGroup)
-	a.Equal(log.LogStream, data.LogStream)
-	a.Equal(log.Owner, data.Owner)
-}
-
 func TestS3ProcessRecordDropped(t *testing.T) {
 	a := assert.New(t)
 
 	in := events.KinesisFirehoseEventRecord{
-		RecordID: "AAA",
+		RecordID: "record1",
 		Data:     []byte{},
 	}
 
 	data := events.CloudwatchLogsData{
-		Owner:       "an owner",
-		LogGroup:    "some log group",
-		LogStream:   "a log stream",
+		Owner:       "owner1",
+		LogGroup:    "loggroup",
 		MessageType: dataMessage,
 		LogEvents: []events.CloudwatchLogsLogEvent{
 			{

--- a/lambda/eks_s3/cloudwatch_eks_to_s3_test.go
+++ b/lambda/eks_s3/cloudwatch_eks_to_s3_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestS3ProcessRecordOK(t *testing.T) {
+	a := assert.New(t)
+
+	in := events.KinesisFirehoseEventRecord{
+		RecordID: "AAA",
+		Data:     []byte{},
+	}
+
+	data := events.CloudwatchLogsData{
+		Owner:       "an owner",
+		LogGroup:    "/aws/eks/some-cluster-name/cluster",
+		LogStream:   "a log stream",
+		MessageType: dataMessage,
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{
+				ID:        "asfd",
+				Message:   "asfd",
+				Timestamp: 123123,
+			},
+		},
+	}
+
+	b, err := json.Marshal(data)
+	a.Nil(err)
+
+	compressed := bytes.NewBuffer(nil)
+	g := gzip.NewWriter(compressed)
+	_, err = g.Write(b)
+	a.Nil(err)
+	err = g.Close()
+	a.Nil(err)
+	in.Data = compressed.Bytes()
+
+	out, err := processRecord(in)
+	a.Nil(err)
+
+	a.Equal(out.RecordID, in.RecordID)
+	a.Equal(out.Result, events.KinesisFirehoseTransformedStateOk)
+
+	r := bufio.NewReader(bytes.NewBuffer(out.Data))
+
+	l, _, err := r.ReadLine()
+	a.Nil(err)
+
+	log := &augmentedLogEvent{}
+	err = json.Unmarshal(l, log)
+	a.Nil(err)
+
+	a.Equal(log.LogGroup, data.LogGroup)
+	a.Equal(log.LogStream, data.LogStream)
+	a.Equal(log.Owner, data.Owner)
+}
+
+func TestS3ProcessRecordDropped(t *testing.T) {
+	a := assert.New(t)
+
+	in := events.KinesisFirehoseEventRecord{
+		RecordID: "AAA",
+		Data:     []byte{},
+	}
+
+	data := events.CloudwatchLogsData{
+		Owner:       "an owner",
+		LogGroup:    "some log group",
+		LogStream:   "a log stream",
+		MessageType: dataMessage,
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{
+				ID:        "asfd",
+				Message:   "asfd",
+				Timestamp: 123123,
+			},
+		},
+	}
+
+	b, err := json.Marshal(data)
+	a.Nil(err)
+
+	compressed := bytes.NewBuffer(nil)
+	g := gzip.NewWriter(compressed)
+	_, err = g.Write(b)
+	a.Nil(err)
+	err = g.Close()
+	a.Nil(err)
+	in.Data = compressed.Bytes()
+
+	out, err := processRecord(in)
+	a.Nil(err)
+
+	a.Equal(out.RecordID, in.RecordID)
+	a.Equal(out.Result, events.KinesisFirehoseTransformedStateDropped)
+}


### PR DESCRIPTION
lamba transformation function for records placed into kinesis from cloudwatch. This function process only EKS Logs and drops all other logs.

This has been tested by verifying cloudwatch EKS logs getting stored into S3 after successful lambda processing.