### PR TITLE
feature: oidc_cli: Allow specifying oauth2 AuthStyle

### DIFF
--- a/oidc_cli/client/client.go
+++ b/oidc_cli/client/client.go
@@ -18,10 +18,12 @@ import (
 
 // Client is an oauth client
 type Client struct {
-	provider       *oidc.Provider
-	oauthConfig    *oauth2.Config
-	verifier       *oidc.IDTokenVerifier
-	server         *server
+	provider    *oidc.Provider
+	oauthConfig *oauth2.Config
+	verifier    *oidc.IDTokenVerifier
+	server      *server
+
+	// Extra configuration options
 	customMessages map[oidcStatus]string
 }
 

--- a/oidc_cli/client/config_options.go
+++ b/oidc_cli/client/config_options.go
@@ -1,5 +1,7 @@
 package client
 
+import "golang.org/x/oauth2"
+
 const (
 	defaultSuccessMessage = "Signed in successfully! You can now return to CLI."
 )
@@ -13,5 +15,11 @@ type Option func(*Client)
 var SetSuccessMessage = func(successMessage string) Option {
 	return func(c *Client) {
 		c.customMessages[oidcStatusSuccess] = successMessage
+	}
+}
+
+var SetOauth2AuthStyle = func(authStyle oauth2.AuthStyle) Option {
+	return func(c *Client) {
+		c.oauthConfig.Endpoint.AuthStyle = authStyle
 	}
 }


### PR DESCRIPTION
Allow oidc to specify the auth server's authstyle (instead of always reverting to autodiscover) to save on requests issued.