### PR TITLE
[feature] Wrapper for interacting with Databricks REST API

### DIFF
--- a/databricks/connect.go
+++ b/databricks/connect.go
@@ -1,0 +1,98 @@
+package databricks
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	APIVersion = "2.0" //APIVersion is the version of the RESTful API of DataBricks
+)
+
+// DBClientOption is used to configure the DataBricks Client
+type DBClientOption struct {
+	User           string
+	Password       string
+	Host           string
+	Token          string
+	DefaultHeaders map[string]string
+	TimeoutSeconds int
+	client         http.Client
+}
+
+// Init initializes the client
+func (o *DBClientOption) Init() {
+	if o.TimeoutSeconds == 0 {
+		o.TimeoutSeconds = 10
+	}
+
+	o.client = http.Client{
+		Timeout: time.Duration(o.TimeoutSeconds) * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: false,
+			},
+		},
+	}
+}
+
+func (o *DBClientOption) getHTTPClient() http.Client {
+	return o.client
+}
+
+func (o *DBClientOption) getAuthHeader() map[string]string {
+	auth := make(map[string]string)
+
+	if o.User != "" && o.Password != "" {
+		encodedAuth := []byte(o.User + ":" + o.Password)
+		userHeaderData := "Basic " + base64.StdEncoding.EncodeToString(encodedAuth)
+		auth["Authorization"] = userHeaderData
+		auth["Content-Type"] = "application/json"
+	} else if o.Token != "" {
+		auth["Authorization"] = "Bearer " + o.Token
+		auth["Content-Type"] = "application/json"
+	}
+
+	return auth
+}
+
+func (o *DBClientOption) getUserAgentHeader() map[string]string {
+	return map[string]string{
+		"User-Agent": "go-misc:databricks",
+	}
+}
+
+func (o *DBClientOption) getDefaultHeaders() map[string]string {
+	auth := o.getAuthHeader()
+	userAgent := o.getUserAgentHeader()
+
+	defaultHeaders := make(map[string]string)
+	for k, v := range auth {
+		defaultHeaders[k] = v
+	}
+
+	for k, v := range o.DefaultHeaders {
+		defaultHeaders[k] = v
+	}
+
+	for k, v := range userAgent {
+		defaultHeaders[k] = v
+	}
+
+	return defaultHeaders
+}
+
+func (o *DBClientOption) getRequestURI(path string) (string, error) {
+	parsedURI, err := url.Parse(o.Host)
+	if err != nil {
+		return "", err
+	}
+
+	requestURI := fmt.Sprintf("%s://%s/api/%s%s", parsedURI.Scheme, parsedURI.Host, APIVersion, path)
+
+	return requestURI, nil
+}

--- a/databricks/connect_test.go
+++ b/databricks/connect_test.go
@@ -1,0 +1,12 @@
+package databricks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	r := require.New(t)
+	r.Nil(nil)
+}

--- a/databricks/query.go
+++ b/databricks/query.go
@@ -1,0 +1,62 @@
+package databricks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/google/go-querystring/query"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func (o *DBClientOption) craftRequest(ctx context.Context, requestEndpoint, method string, requestData interface{}) (*http.Request, error) {
+	// Default info determined by *DBClientOption
+	requestURL, err := o.getRequestURI(requestEndpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create requestURL")
+	}
+
+	requestHeaders := o.getDefaultHeaders()
+
+	var requestBody []byte
+
+	// Crafting the right URL and requestBody
+	if method == "GET" {
+		params, err := query.Values(requestData)
+		if err != nil {
+			return nil, errors.Wrap(err, "Unable to craft query for GET request")
+		}
+
+		requestURL += "?" + params.Encode()
+	} else {
+		bodyBytes, err := json.Marshal(requestData)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Unable to craft request body for %s request", method)
+		}
+		requestBody = bodyBytes
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, requestURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create a HTTP request with given inputs")
+	}
+
+	// Setting databricks-specific headers
+	for k, v := range requestHeaders {
+		request.Header.Set(k, v)
+	}
+
+	// Save a copy of this request for debugging.
+	requestDump, err := httputil.DumpRequest(request, true)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	logrus.Debug(string(requestDump))
+
+	return request, nil
+}

--- a/databricks/query_test.go
+++ b/databricks/query_test.go
@@ -1,0 +1,12 @@
+package databricks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListSecrets(t *testing.T) {
+	r := require.New(t)
+	r.Nil(nil)
+}

--- a/databricks/secrets.go
+++ b/databricks/secrets.go
@@ -1,0 +1,383 @@
+package databricks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+func (o *DBClientOption) CreateSecretScope(ctx context.Context, scope, initial_manage_principal string) error {
+	data := map[string]string{
+		"scope":                    scope,
+		"initial_manage_principal": initial_manage_principal,
+	}
+	httpRequest, err := o.craftRequest(ctx, "/secrets/scopes/create", "POST", data)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to execute http request")
+	}
+
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (o *DBClientOption) DeleteSecretScope(ctx context.Context, scope string) error {
+	data := map[string]string{
+		"scope": scope,
+	}
+	httpRequest, err := o.craftRequest(ctx, "/secrets/scopes/delete", "POST", data)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to execute http request")
+	}
+
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (o *DBClientOption) ListSecretScopes(ctx context.Context) ([]SecretScope, error) {
+	// GET
+	data := map[string]string{}
+
+	var scopes []SecretScope
+
+	httpRequest, err := o.craftRequest(ctx, "/secrets/scopes/list", "GET", data)
+	if err != nil {
+		return scopes, errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return scopes, errors.Wrap(err, "Unable to execute http request")
+	}
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return scopes, errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return scopes, fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	// Unmarshal to interface
+	var respMap map[string]interface{}
+	err = json.Unmarshal(body, respMap)
+	if err != nil {
+		return scopes, errors.Wrapf(err, "Unable to unmarshal http response's body to map[string]interface. Got %T", resp.Body)
+	}
+
+	scopesInterface, ok := respMap["scopes"]
+	if !ok {
+		return scopes, errors.Wrap(err, "ListSecretScopes() response body doesn't contain 'scopes' key")
+	}
+
+	scopes, ok = scopesInterface.([]SecretScope)
+	if !ok {
+		return scopes, errors.Wrap(err, "Unable to convert scopesInterface value to type []SecretScope")
+	}
+
+	return scopes, errors.Wrap(err, "Unable to unmarshal http request body to SecretScopes array")
+}
+
+func (o *DBClientOption) PutSecret(ctx context.Context, scope, key string) error {
+	// Get the secret as a bytes so we can plug in bytes_value into request
+	data := map[string]string{
+		"scope": scope,
+		"key":   key,
+	}
+	httpRequest, err := o.craftRequest(ctx, "/secrets/put", "POST", data)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to execute http request")
+	}
+
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	// secret key must consist of alphanumeric characters, dashes, underscores, and periods
+	// 	it cannot exceed 128 characters
+	// 	Maximum allowed secret value size is 128 kb
+	// 	Maximum number of secrets in a given scope is 1000
+	return nil
+}
+
+func (o *DBClientOption) DeleteSecret(ctx context.Context, scope, key string) error {
+	data := map[string]string{
+		"scope": scope,
+		"key":   key,
+	}
+	httpRequest, err := o.craftRequest(ctx, "/secrets/delete", "POST", data)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to execute http request")
+	}
+
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read http response body")
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	// User must have write or manage permission on the secret scope
+	return nil
+}
+
+func (o *DBClientOption) ListSecrets(ctx context.Context, scope string) ([]SecretMetadata, error) {
+	// GET
+	data := map[string]string{
+		"scope": scope,
+	}
+	var secrets []SecretMetadata
+	httpRequest, err := o.craftRequest(ctx, "/secrets/list", "GET", data)
+	if err != nil {
+		return secrets, errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return secrets, errors.Wrap(err, "Unable to execute http request")
+	}
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return secrets, errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return secrets, fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	// TODO: Get the "secrets" item in JSON body first, then unmarshal & decode
+	var respMap map[string]interface{}
+	err = json.Unmarshal(body, respMap)
+	if err != nil {
+		return secrets, errors.Wrapf(err, "Unable to unmarshal http response's body to map[string]interface. Got %T", resp.Body)
+	}
+
+	secretsInterface, ok := respMap["secrets"]
+	if !ok {
+		return secrets, errors.Wrap(err, "ListSecrets() response body doesn't contain 'secrets' key")
+	}
+
+	secrets, ok = secretsInterface.([]SecretMetadata)
+	if !ok {
+		return secrets, errors.Wrap(err, "Unable to convert secretsInterface value to type []SecretMetadata")
+	}
+
+	return secrets, errors.Wrap(err, "Unable to unmarshal http request body to Secrets array")
+}
+
+func (o *DBClientOption) PutSecretACL(ctx context.Context, scope, principal string, permission AclPermission) error {
+	// Must have kindManage permission to invoke this API
+	data := map[string]string{
+		"scope":      scope,
+		"principal":  principal,
+		"permission": string(permission),
+	}
+	httpRequest, err := o.craftRequest(ctx, "/secrets/acls/put", "POST", data)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to execute http request")
+	}
+
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (o *DBClientOption) DeleteSecretACL(ctx context.Context, scope, principal string) error {
+	data := map[string]string{
+		"scope":     scope,
+		"principal": principal,
+	}
+	httpRequest, err := o.craftRequest(ctx, "/secrets/acls/delete", "POST", data)
+	if err != nil {
+		return errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to execute http request")
+	}
+
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (o *DBClientOption) GetSecretACL(ctx context.Context, scope, principal string) (AclItem, error) {
+	data := map[string]string{
+		"scope":     scope,
+		"principal": principal,
+	}
+	var acl AclItem
+	httpRequest, err := o.craftRequest(ctx, "/secrets/acls/get", "GET", data)
+	if err != nil {
+		return acl, errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return acl, errors.Wrap(err, "Unable to execute http request")
+	}
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return acl, errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return acl, fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	dec.DisallowUnknownFields()
+
+	err = dec.Decode(&acl)
+
+	return acl, errors.Wrap(err, "Unable to unmarshal http request body to AclItem type")
+}
+
+func (o *DBClientOption) ListSecretACLs(ctx context.Context, scope string) ([]AclItem, error) {
+	// GET
+	data := map[string]string{
+		"scope": scope,
+	}
+
+	var acls []AclItem
+
+	httpRequest, err := o.craftRequest(ctx, "/secrets/acls/list", "GET", data)
+	if err != nil {
+		return acls, errors.Wrap(err, "Unable to create http request")
+	}
+
+	httpClient := o.getHTTPClient()
+
+	resp, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return acls, errors.Wrap(err, "Unable to execute http request")
+	}
+	defer resp.Body.Close()
+	// We should be able to read the request body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return acls, errors.Wrap(err, "Unable to read http response body")
+	}
+
+	if resp.StatusCode != 200 {
+		return acls, fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
+	}
+
+	var respMap map[string]interface{}
+	err = json.Unmarshal(body, respMap)
+	if err != nil {
+		return acls, errors.Wrapf(err, "Unable to unmarshal http response's body to map[string]interface. Got %T", resp.Body)
+	}
+
+	aclsInterface, ok := respMap["items"]
+	if !ok {
+		return acls, errors.Wrap(err, "ListSecretACLs() response body doesn't contain 'acls' key")
+	}
+
+	acls, ok = aclsInterface.([]AclItem)
+	if !ok {
+		return acls, errors.Wrap(err, "Unable to convert aclsInterface value to type []AclItem")
+	}
+
+	return acls, errors.Wrap(err, "Unable to unmarshal http request body to Secrets array")
+}

--- a/databricks/secrets.go
+++ b/databricks/secrets.go
@@ -9,11 +9,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (o *DBClientOption) CreateSecretScope(ctx context.Context, scope, initial_manage_principal string) error {
+func (o *DBClientOption) CreateSecretScope(ctx context.Context, scope, initialManagePrincipal string) error {
 	data := map[string]string{
 		"scope":                    scope,
-		"initial_manage_principal": initial_manage_principal,
+		"initial_manage_principal": initialManagePrincipal,
 	}
+
 	httpRequest, err := o.craftRequest(ctx, "/secrets/scopes/create", "POST", data)
 	if err != nil {
 		return errors.Wrap(err, "Unable to create http request")
@@ -71,7 +72,6 @@ func (o *DBClientOption) DeleteSecretScope(ctx context.Context, scope string) er
 }
 
 func (o *DBClientOption) ListSecretScopes(ctx context.Context) ([]SecretScope, error) {
-	// GET
 	data := map[string]string{}
 
 	var scopes []SecretScope
@@ -100,7 +100,8 @@ func (o *DBClientOption) ListSecretScopes(ctx context.Context) ([]SecretScope, e
 
 	// Unmarshal to interface
 	var respMap map[string]interface{}
-	err = json.Unmarshal(body, respMap)
+
+	err = json.Unmarshal(body, &respMap)
 	if err != nil {
 		return scopes, errors.Wrapf(err, "Unable to unmarshal http response's body to map[string]interface. Got %T", resp.Body)
 	}
@@ -186,11 +187,12 @@ func (o *DBClientOption) DeleteSecret(ctx context.Context, scope, key string) er
 }
 
 func (o *DBClientOption) ListSecrets(ctx context.Context, scope string) ([]SecretMetadata, error) {
-	// GET
 	data := map[string]string{
 		"scope": scope,
 	}
+
 	var secrets []SecretMetadata
+
 	httpRequest, err := o.craftRequest(ctx, "/secrets/list", "GET", data)
 	if err != nil {
 		return secrets, errors.Wrap(err, "Unable to create http request")
@@ -215,7 +217,7 @@ func (o *DBClientOption) ListSecrets(ctx context.Context, scope string) ([]Secre
 
 	// TODO: Get the "secrets" item in JSON body first, then unmarshal & decode
 	var respMap map[string]interface{}
-	err = json.Unmarshal(body, respMap)
+	err = json.Unmarshal(body, &respMap)
 	if err != nil {
 		return secrets, errors.Wrapf(err, "Unable to unmarshal http response's body to map[string]interface. Got %T", resp.Body)
 	}
@@ -233,7 +235,7 @@ func (o *DBClientOption) ListSecrets(ctx context.Context, scope string) ([]Secre
 	return secrets, errors.Wrap(err, "Unable to unmarshal http request body to Secrets array")
 }
 
-func (o *DBClientOption) PutSecretACL(ctx context.Context, scope, principal string, permission AclPermission) error {
+func (o *DBClientOption) PutSecretACL(ctx context.Context, scope, principal string, permission ACLPermission) error {
 	// Must have kindManage permission to invoke this API
 	data := map[string]string{
 		"scope":      scope,
@@ -297,12 +299,12 @@ func (o *DBClientOption) DeleteSecretACL(ctx context.Context, scope, principal s
 	return nil
 }
 
-func (o *DBClientOption) GetSecretACL(ctx context.Context, scope, principal string) (AclItem, error) {
+func (o *DBClientOption) GetSecretACL(ctx context.Context, scope, principal string) (ACLItem, error) {
 	data := map[string]string{
 		"scope":     scope,
 		"principal": principal,
 	}
-	var acl AclItem
+	var acl ACLItem
 	httpRequest, err := o.craftRequest(ctx, "/secrets/acls/get", "GET", data)
 	if err != nil {
 		return acl, errors.Wrap(err, "Unable to create http request")
@@ -333,13 +335,12 @@ func (o *DBClientOption) GetSecretACL(ctx context.Context, scope, principal stri
 	return acl, errors.Wrap(err, "Unable to unmarshal http request body to AclItem type")
 }
 
-func (o *DBClientOption) ListSecretACLs(ctx context.Context, scope string) ([]AclItem, error) {
-	// GET
+func (o *DBClientOption) ListSecretACLs(ctx context.Context, scope string) ([]ACLItem, error) {
 	data := map[string]string{
 		"scope": scope,
 	}
 
-	var acls []AclItem
+	var acls []ACLItem
 
 	httpRequest, err := o.craftRequest(ctx, "/secrets/acls/list", "GET", data)
 	if err != nil {
@@ -364,7 +365,7 @@ func (o *DBClientOption) ListSecretACLs(ctx context.Context, scope string) ([]Ac
 	}
 
 	var respMap map[string]interface{}
-	err = json.Unmarshal(body, respMap)
+	err = json.Unmarshal(body, &respMap)
 	if err != nil {
 		return acls, errors.Wrapf(err, "Unable to unmarshal http response's body to map[string]interface. Got %T", resp.Body)
 	}
@@ -374,7 +375,7 @@ func (o *DBClientOption) ListSecretACLs(ctx context.Context, scope string) ([]Ac
 		return acls, errors.Wrap(err, "ListSecretACLs() response body doesn't contain 'acls' key")
 	}
 
-	acls, ok = aclsInterface.([]AclItem)
+	acls, ok = aclsInterface.([]ACLItem)
 	if !ok {
 		return acls, errors.Wrap(err, "Unable to convert aclsInterface value to type []AclItem")
 	}

--- a/databricks/secrets.go
+++ b/databricks/secrets.go
@@ -148,10 +148,6 @@ func (o *DBClientOption) PutSecret(ctx context.Context, scope, key string) error
 		return fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
 	}
 
-	// secret key must consist of alphanumeric characters, dashes, underscores, and periods
-	// 	it cannot exceed 128 characters
-	// 	Maximum allowed secret value size is 128 kb
-	// 	Maximum number of secrets in a given scope is 1000
 	return nil
 }
 
@@ -215,7 +211,6 @@ func (o *DBClientOption) ListSecrets(ctx context.Context, scope string) ([]Secre
 		return secrets, fmt.Errorf("Response from server (%d) %s", resp.StatusCode, string(body))
 	}
 
-	// TODO: Get the "secrets" item in JSON body first, then unmarshal & decode
 	var respMap map[string]interface{}
 	err = json.Unmarshal(body, &respMap)
 	if err != nil {

--- a/databricks/secrets_test.go
+++ b/databricks/secrets_test.go
@@ -1,0 +1,1 @@
+package databricks

--- a/databricks/secrets_types.go
+++ b/databricks/secrets_types.go
@@ -1,0 +1,28 @@
+package databricks
+
+type AclItem struct {
+	Principal  string        `json:"principal"`
+	Permission AclPermission `json:"permission"`
+}
+
+type AclPermission string
+
+const (
+	KindRead   AclPermission = "READ"
+	KindWrite  AclPermission = "WRITE"
+	KindManage AclPermission = "MANAGE"
+)
+
+type ScopeBackendType string
+
+const DatabricksBackend ScopeBackendType = "DATABRICKS"
+
+type SecretScope struct {
+	Name         string           `json:"name"`
+	Backend_type ScopeBackendType `json:"backend_type"`
+}
+
+type SecretMetadata struct {
+	Key                    string `json:"key"`
+	Last_updated_timestamp int64  `json:"last_updated_timestamp"`
+}

--- a/databricks/secrets_types.go
+++ b/databricks/secrets_types.go
@@ -1,16 +1,16 @@
 package databricks
 
-type AclItem struct {
+type ACLItem struct {
 	Principal  string        `json:"principal"`
-	Permission AclPermission `json:"permission"`
+	Permission ACLPermission `json:"permission"`
 }
 
-type AclPermission string
+type ACLPermission string
 
 const (
-	KindRead   AclPermission = "READ"
-	KindWrite  AclPermission = "WRITE"
-	KindManage AclPermission = "MANAGE"
+	KindRead   ACLPermission = "READ"
+	KindWrite  ACLPermission = "WRITE"
+	KindManage ACLPermission = "MANAGE"
 )
 
 type ScopeBackendType string
@@ -18,11 +18,11 @@ type ScopeBackendType string
 const DatabricksBackend ScopeBackendType = "DATABRICKS"
 
 type SecretScope struct {
-	Name         string           `json:"name"`
-	Backend_type ScopeBackendType `json:"backend_type"`
+	Name        string           `json:"name"`
+	BackendType ScopeBackendType `json:"backend_type"`
 }
 
 type SecretMetadata struct {
-	Key                    string `json:"key"`
-	Last_updated_timestamp int64  `json:"last_updated_timestamp"`
+	Key                  string `json:"key"`
+	LastUpdatedTimestamp int64  `json:"last_updated_timestamp"`
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/go-github/v27 v27.0.6
+	github.com/google/go-querystring v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/gruntwork-io/terratest v0.29.0

--- a/snowflake/connect.go
+++ b/snowflake/connect.go
@@ -20,6 +20,10 @@ type SnowflakeConfig struct {
 }
 
 func ConfigureSnowflakeDB(s *SnowflakeConfig) (*sql.DB, error) {
+	if s == nil {
+		return nil, errors.New("nil SnowflakeConfig input")
+	}
+
 	dsn, err := DSN(s)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build dsn for snowflake connection")
@@ -29,6 +33,9 @@ func ConfigureSnowflakeDB(s *SnowflakeConfig) (*sql.DB, error) {
 }
 
 func DSN(conf *SnowflakeConfig) (string, error) {
+	if conf == nil {
+		return "", errors.New("nil SnowflakeConfig input")
+	}
 	// us-west-2 is their default region, but if you actually specify that it won't trigger their default code
 	//  https://github.com/snowflakedb/gosnowflake/blob/52137ce8c32eaf93b0bd22fc5c7297beff339812/dsn.go#L61
 	if conf.Region == "us-west-2" {


### PR DESCRIPTION
I spent ~ 2 hrs trying to figure out a better way to interact w/ databricks (compared to [this repo](https://github.com/xinsnake/databricks-sdk-golang)) and wrote this secrets wrapper. It's a big PR though, so this probably won't get merged as-is? I'm also not sure if this belongs in go-misc. In an ideal world, this would be like aws-sdk-go

still needs tests