### PR TITLE
[fix] convert keypair marshaling to pkcs8 because snowflake suggests it

### DIFF
--- a/snowflake/connect_test.go
+++ b/snowflake/connect_test.go
@@ -28,7 +28,7 @@ func TestDSN(t *testing.T) {
 	testPriv, err := keypair.GenerateRSAKeypair()
 	r.NoError(err)
 
-	privKeyBuffer, _, err := keypair.SaveRSAKeys(testPriv)
+	privKeyBuffer, err := keypair.SaveRSAKey(testPriv)
 	r.NoError(err)
 
 	// TempFile replaces * with a random number
@@ -71,7 +71,7 @@ func TestConfigureSnowflakeDB(t *testing.T) {
 	testPriv, err := keypair.GenerateRSAKeypair()
 	r.NoError(err)
 
-	privKeyBuffer, _, err := keypair.SaveRSAKeys(testPriv)
+	privKeyBuffer, err := keypair.SaveRSAKey(testPriv)
 	r.NoError(err)
 
 	// TempFile replaces * with a random number


### PR DESCRIPTION
In another PR, I had trouble with updating RSA_PUBLIC_KEY_2 due to an invalid public key type. I think this will help because [this link](https://community.snowflake.com/s/article/How-to-verify-the-Public-Private-Key-Connectivity-using-SnowSQL) seems to have pk8 flags turned on.

```
 a)   Unencrypted version
              To generate an unencrypted version of private key, use the following command:
                $ openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt

               To generate an unencrypted version of public key, use the following command:
                $ openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
```