### PR TITLE
[fix] delete unnecessary codeQL step

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,11 +19,6 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
[This build](https://github.com/chanzuckerberg/go-misc/pull/174/checks?check_run_id=2238808342) showed this warning:
```
Warning: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. 
Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
```