### PR TITLE
[fix] rename snowflake config to reduce redundancy

### DIFF
--- a/lambda/rotator-snowflake/setup/snowflake/snowflake.go
+++ b/lambda/rotator-snowflake/setup/snowflake/snowflake.go
@@ -12,7 +12,7 @@ import (
 )
 
 func configureConnection(env *SnowflakeClientEnv) (*sql.DB, error) {
-	cfg := snowflake.SnowflakeConfig{
+	cfg := snowflake.Config{
 		Account:  env.NAME,
 		User:     env.USER,
 		Role:     env.ROLE,

--- a/snowflake/connect.go
+++ b/snowflake/connect.go
@@ -8,7 +8,7 @@ import (
 	"github.com/snowflakedb/gosnowflake"
 )
 
-type SnowflakeConfig struct {
+type Config struct {
 	Account          string `yaml:"account"`
 	User             string `yaml:"username"`
 	Password         string `yaml:"password"`
@@ -19,7 +19,7 @@ type SnowflakeConfig struct {
 	Role             string `yaml:"role"`
 }
 
-func ConfigureSnowflakeDB(s *SnowflakeConfig) (*sql.DB, error) {
+func ConfigureSnowflakeDB(s *Config) (*sql.DB, error) {
 	dsn, err := DSN(s)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build dsn for snowflake connection")
@@ -28,7 +28,7 @@ func ConfigureSnowflakeDB(s *SnowflakeConfig) (*sql.DB, error) {
 	return Open(dsn)
 }
 
-func DSN(conf *SnowflakeConfig) (string, error) {
+func DSN(conf *Config) (string, error) {
 	// us-west-2 is their default region, but if you actually specify that it won't trigger their default code
 	//  https://github.com/snowflakedb/gosnowflake/blob/52137ce8c32eaf93b0bd22fc5c7297beff339812/dsn.go#L61
 	if conf.Region == "us-west-2" {

--- a/snowflake/connect_test.go
+++ b/snowflake/connect_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testSnowflakeConfig = SnowflakeConfig{
+var testSnowflakeConfig = Config{
 	Account:          "test-acct",
 	User:             "test-user",
 	Password:         "test-password",


### PR DESCRIPTION
so I get to call snowflake.Config rather than snowflake.SnowflakeConfig