### PR TITLE
Move storage functions to storage module

### DIFF
--- a/oidc_cli/storage/storage.go
+++ b/oidc_cli/storage/storage.go
@@ -24,7 +24,7 @@ type Storage interface {
 	MarshalOpts() []client.MarshalOpts
 }
 
-func GetStorage(clientID string, issuerURL string) (Storage, error) {
+func GetOIDC(clientID string, issuerURL string) (Storage, error) {
 	isWSL, err := osutil.IsWSL()
 	if err != nil {
 		return nil, err

--- a/oidc_cli/storage/storage.go
+++ b/oidc_cli/storage/storage.go
@@ -6,11 +6,12 @@ import (
 	"github.com/chanzuckerberg/go-misc/oidc_cli/client"
 	"github.com/mitchellh/go-homedir"
 	"github.com/chanzuckerberg/go-misc/osutil"
+	"github.com/pkg/errors"
 )
 
 const (
 	service = "aws-oidc"
-
+	defaultFileStorageDir = "~/.oidc-cli"
 	storageVersion = "v0"
 )
 

--- a/oidc_cli/storage/storage.go
+++ b/oidc_cli/storage/storage.go
@@ -24,7 +24,7 @@ type Storage interface {
 	MarshalOpts() []client.MarshalOpts
 }
 
-func getStorage(clientID string, issuerURL string) (Storage, error) {
+func GetStorage(clientID string, issuerURL string) (Storage, error) {
 	isWSL, err := osutil.IsWSL()
 	if err != nil {
 		return nil, err

--- a/oidc_cli/storage/storage.go
+++ b/oidc_cli/storage/storage.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	service = "aws-oidc"
-	defaultFileStorageDir = "~/.oidc-cli"
+	defaultFileStorageDir = "~/.cache/oidc-cli"
 	storageVersion = "v0"
 )
 

--- a/oidc_cli/storage/storage.go
+++ b/oidc_cli/storage/storage.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/chanzuckerberg/go-misc/oidc_cli/client"
+	"github.com/mitchellh/go-homedir"
+	"github.com/chanzuckerberg/go-misc/osutil"
 )
 
 const (
@@ -19,4 +21,32 @@ type Storage interface {
 	Delete(context.Context) error
 
 	MarshalOpts() []client.MarshalOpts
+}
+
+func getStorage(clientID string, issuerURL string) (Storage, error) {
+	isWSL, err := osutil.IsWSL()
+	if err != nil {
+		return nil, err
+	}
+
+	// If WSL we use a file storage which does not cache refreshTokens
+	//    we do this because WSL doesn't have a graphical interface
+	//    and therefore limits how we can interact with a keyring (such as gnome-keyring).
+	// To limit the risks of having a long-lived refresh token around,
+	//    we disable this part of the flow for WSL. This could change in the future
+	//    when we find a better way to work with a WSL secure storage.
+	if isWSL {
+		return getFileStorage(clientID, issuerURL)
+	}
+
+	return NewKeyring(clientID, issuerURL), nil
+}
+
+func getFileStorage(clientID string, issuerURL string) (Storage, error) {
+	dir, err := homedir.Expand(defaultFileStorageDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not expand path")
+	}
+
+	return NewFile(dir, clientID, issuerURL), nil
 }

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -38,7 +38,7 @@ func GetToken(ctx context.Context, clientID string, issuerURL string, clientOpti
 		return nil, errors.Wrap(err, "Unable to create client")
 	}
 
-	storage, err := storage.getStorage(clientID, issuerURL)
+	storage, err := storage.GetStorage(clientID, issuerURL)
 	if err != nil {
 		return nil, err
 	}

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/chanzuckerberg/go-misc/oidc_cli/client"
 	"github.com/chanzuckerberg/go-misc/oidc_cli/storage"
 	"github.com/chanzuckerberg/go-misc/pidlock"
+)
 
 const (
 	lockFilePath          = "/tmp/aws-oidc.lock"

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/chanzuckerberg/go-misc/oidc_cli/client"
 	"github.com/chanzuckerberg/go-misc/oidc_cli/storage"
 	"github.com/chanzuckerberg/go-misc/pidlock"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -7,11 +7,7 @@ import (
 	"github.com/chanzuckerberg/go-misc/oidc_cli/cache"
 	"github.com/chanzuckerberg/go-misc/oidc_cli/client"
 	"github.com/chanzuckerberg/go-misc/oidc_cli/storage"
-	"github.com/chanzuckerberg/go-misc/osutil"
 	"github.com/chanzuckerberg/go-misc/pidlock"
-	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
-)
 
 const (
 	lockFilePath          = "/tmp/aws-oidc.lock"
@@ -42,7 +38,7 @@ func GetToken(ctx context.Context, clientID string, issuerURL string, clientOpti
 		return nil, errors.Wrap(err, "Unable to create client")
 	}
 
-	storage, err := getStorage(clientID, issuerURL)
+	storage, err := storage.getStorage(clientID, issuerURL)
 	if err != nil {
 		return nil, err
 	}
@@ -57,32 +53,4 @@ func GetToken(ctx context.Context, clientID string, issuerURL string, clientOpti
 		return nil, errors.New("nil token from OIDC-IDP")
 	}
 	return token, nil
-}
-
-func getStorage(clientID string, issuerURL string) (storage.Storage, error) {
-	isWSL, err := osutil.IsWSL()
-	if err != nil {
-		return nil, err
-	}
-
-	// If WSL we use a file storage which does not cache refreshTokens
-	//    we do this because WSL doesn't have a graphical interface
-	//    and therefore limits how we can interact with a keyring (such as gnome-keyring).
-	// To limit the risks of having a long-lived refresh token around,
-	//    we disable this part of the flow for WSL. This could change in the future
-	//    when we find a better way to work with a WSL secure storage.
-	if isWSL {
-		return getFileStorage(clientID, issuerURL)
-	}
-
-	return storage.NewKeyring(clientID, issuerURL), nil
-}
-
-func getFileStorage(clientID string, issuerURL string) (storage.Storage, error) {
-	dir, err := homedir.Expand(defaultFileStorageDir)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not expand path")
-	}
-
-	return storage.NewFile(dir, clientID, issuerURL), nil
 }

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	lockFilePath          = "/tmp/aws-oidc.lock"
-	defaultFileStorageDir = "~/.oidc-cli"
 )
 
 // GetToken gets an oidc token.

--- a/oidc_cli/token_getter.go
+++ b/oidc_cli/token_getter.go
@@ -37,7 +37,7 @@ func GetToken(ctx context.Context, clientID string, issuerURL string, clientOpti
 		return nil, errors.Wrap(err, "Unable to create client")
 	}
 
-	storage, err := storage.GetStorage(clientID, issuerURL)
+	storage, err := storage.GetOIDC(clientID, issuerURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
getStorage and getFileStorage were previously located in token_getter.go, but moving them here makes it easier to use the same storage for non token_getting purposes.