### PR TITLE
fix[logger]: changing logger to logrus 

### DIFF
--- a/snowflake/db.go
+++ b/snowflake/db.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"regexp"
 
 	"github.com/luna-duclos/instrumentedsql"
+	"github.com/sirupsen/logrus"
 	"github.com/snowflakedb/gosnowflake"
 )
 
@@ -16,7 +16,7 @@ func init() {
 
 	logger := instrumentedsql.LoggerFunc(func(ctx context.Context, msg string, keyvals ...interface{}) {
 		s := fmt.Sprintf("[DEBUG] %s %v\n", msg, keyvals)
-		log.Println(re.ReplaceAllString(s, " "))
+		logrus.Debugln(re.ReplaceAllString(s, " "))
 	})
 
 	sql.Register("snowflake-instrumented", instrumentedsql.WrapDriver(&gosnowflake.SnowflakeDriver{}, instrumentedsql.WithLogger(logger)))


### PR DESCRIPTION
This PR changes the configured logger to logrus so it carries over the debugging information from the logrus processing chain that might be used by users of this library. For example, if a user of this library turns off debug logs, the logs from the database tracing won't be logged for that user. 