### PR TITLE
feat: compress token before storing in cache to allow for larger tokens to be cached

### DIFF
--- a/.github/actions/find-changed-packages/action.yml
+++ b/.github/actions/find-changed-packages/action.yml
@@ -24,7 +24,7 @@ runs:
           const path = require("path")
           const fs = require("fs")
           const changedFiles = ${{ steps.filter.outputs.changed_files }}
-          const changedDirs = changedFiles.map(f => path.dirname(f))
+          const changedDirs = changedFiles.map(f => path.dirname(f).split('/')[0])
           const changedGoPackages = changedDirs.filter(d => fs.existsSync(path.join(d, "go.mod")))
           const uniqueChangedGoPackages = [...new Set(changedGoPackages)];
 

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -64,8 +64,10 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	if err != nil {
 		return nil, err
 	}
+	logrus.Info("...got cachedToken ", cachedToken)
 	// if we have a valid token, use it
 	if cachedToken.IsFresh() {
+		logrus.Info("...cachedToken is fresh")
 		return cachedToken, nil
 	}
 
@@ -105,9 +107,6 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to cache the strToken")
 	}
-
-	logrus.Info("token", token)
-	// logrus.Info(len(token.))
 
 	return token, nil
 }

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -110,6 +110,12 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 		return nil, errors.Wrap(err, "Unable to cache the strToken")
 	}
 
+	cached, err := c.storage.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Info("...storage.Read ", cached)
+
 	return token, nil
 }
 

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -95,7 +95,11 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	tw := tar.NewWriter(gzw)
 	tw.Write([]byte(strToken))
 
-	err = c.storage.Set(ctx, string(buf.Bytes()))
+	compressedToken := buf.String()
+	logrus.Info(compressedToken)
+	logrus.Info(len(compressedToken))
+
+	err = c.storage.Set(ctx, compressedToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to cache the strToken")
 	}

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -1,6 +1,9 @@
 package cache
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 
 	"github.com/chanzuckerberg/go-misc/oidc_cli/oidc_impl/client"
@@ -84,7 +87,15 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 		return nil, errors.Wrap(err, "unable to marshall token")
 	}
 	// save token to storage
-	err = c.storage.Set(ctx, strToken)
+
+	logrus.Info(strToken)
+	logrus.Info(len(strToken))
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	tw.Write([]byte(strToken))
+
+	err = c.storage.Set(ctx, string(buf.Bytes()))
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to cache the strToken")
 	}

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
-	"archive/tar"
 	"bytes"
 	"compress/gzip"
 	"context"
+	"fmt"
 
 	"github.com/chanzuckerberg/go-misc/oidc_cli/oidc_impl/client"
 	"github.com/chanzuckerberg/go-misc/oidc_cli/oidc_impl/storage"
@@ -93,11 +93,13 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	logrus.Info("strToken", strToken)
 	logrus.Info(len(strToken))
 	var buf bytes.Buffer
-	gzw := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gzw)
-	tw.Write([]byte(strToken))
-	gzw.Close()
-	tw.Close()
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write([]byte(strToken)); err != nil {
+		return nil, fmt.Errorf("failed to write to gzip: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close gzip: %w", err)
+	}
 
 	compressedToken := buf.String()
 	logrus.Info("compressedToken", compressedToken)

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -88,7 +88,7 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	}
 	// save token to storage
 
-	logrus.Info(strToken)
+	logrus.Info("strToken", strToken)
 	logrus.Info(len(strToken))
 	var buf bytes.Buffer
 	gzw := gzip.NewWriter(&buf)
@@ -98,13 +98,16 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	tw.Close()
 
 	compressedToken := buf.String()
-	logrus.Info(compressedToken)
+	logrus.Info("compressedToken", compressedToken)
 	logrus.Info(len(compressedToken))
 
 	err = c.storage.Set(ctx, compressedToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to cache the strToken")
 	}
+
+	logrus.Info("token", token)
+	// logrus.Info(len(token.))
 
 	return token, nil
 }

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -115,6 +115,15 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 		return nil, err
 	}
 	logrus.Info("...storage.Read ", cached)
+	if cached != nil {
+		logrus.Info("...storage.Read ", *cached)
+	}
+
+	cachedToken2, err := c.readFromStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Info("...got cachedToken2 ", cachedToken2)
 
 	return token, nil
 }

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -94,6 +94,8 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	gzw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gzw)
 	tw.Write([]byte(strToken))
+	gzw.Close()
+	tw.Close()
 
 	compressedToken := buf.String()
 	logrus.Info(compressedToken)

--- a/oidc_cli/oidc_impl/cache/cache.go
+++ b/oidc_cli/oidc_impl/cache/cache.go
@@ -126,7 +126,8 @@ func (c *Cache) refresh(ctx context.Context) (*client.Token, error) {
 	}
 	logrus.Info("...got cachedToken2 ", cachedToken2)
 
-	return token, nil
+	logrus.Info("...returning cached token")
+	return cachedToken2, nil
 }
 
 // reads token from storage, potentially returning a nil/expired token


### PR DESCRIPTION
Updates module to use gzip compression for tokens stored in cache to allow for larger tokens to be stored. Tokens are compressed prior to writing to the cache and decompressed after reading from the cache.