### PR TITLE
feat: allow adding arbitrary yaml config files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,9 +59,9 @@ func WithConfigFileBaseName[T any](fileNamePrefix string) ConfigOption[T] {
 	}
 }
 
-// WithAdditionalConfigFile allows adding additional config files to be loaded AFTER the main config file and the env config file,
+// WithOverrideConfigFile allows adding additional config files to be loaded AFTER the main config file and the env config file,
 // meaning it will override any values set in the main config file and the env config file.
-func WithAdditionalConfigFile[T any](fileName string) ConfigOption[T] {
+func WithOverrideConfigFile[T any](fileName string) ConfigOption[T] {
 	return func(c *ConfigLoader[T]) error {
 		c.AdditionalConfigFileNames = append(c.AdditionalConfigFileNames, fileName)
 		return nil

--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,6 @@ func (c *ConfigLoader[T]) populateConfiguration(cfg *T) error {
 	// iterate the appConfig files to be used, read the first one and merge the rest
 	for _, configFile := range appConfigFiles {
 		absoluteConfigFilePath := filepath.Join(path, configFile)
-		fmt.Println("...> loading file:", absoluteConfigFilePath)
 		if _, err := os.Stat(absoluteConfigFilePath); err == nil {
 			tmp, err := evaluateConfigWithEnvToTmp(absoluteConfigFilePath)
 			if len(tmp) != 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,6 +69,22 @@ type testConfig struct {
 
 func TestLoadConfigurationBasic(t *testing.T) {
 	r := require.New(t)
+
+	cfg := &testConfig{}
+	err := LoadConfiguration(cfg, WithConfigYamlDir[testConfig]("./testData/basic"))
+	r.NoError(err)
+
+	r.Equal("foo", cfg.Value1)
+	r.Equal("bar", cfg.Value2)
+	r.Equal("zap", cfg.Nested.Value1)
+}
+
+func TestLoadConfigurationBasicDoesntErrorOnMissingFile(t *testing.T) {
+	r := require.New(t)
+
+	// Set the deployment stage to test so it overlays some app-config.<uuid>.yaml file (which doesn't exist and should not error)
+	os.Setenv("DEPLOYMENT_STAGE", uuid.New().String())
+	defer os.Unsetenv("DEPLOYMENT_STAGE")
 
 	cfg := &testConfig{}
 	err := LoadConfiguration(cfg, WithConfigYamlDir[testConfig]("./testData/basic"))
@@ -170,7 +187,7 @@ func TestLoadConfigurationValidatedSucceedWithConfigEditor(t *testing.T) {
 func TestLoadConfigurationValidatedSucceedWithOverlay(t *testing.T) {
 	r := require.New(t)
 
-	// Set the deployment stage to test so it overlays the app-config.test.yaml file
+	// Set the deployment stage to "withvalues" so it overlays the app-config.withvalues.yaml file
 	os.Setenv("DEPLOYMENT_STAGE", "withvalues")
 	defer os.Unsetenv("DEPLOYMENT_STAGE")
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -85,7 +85,7 @@ func TestLoadConfigurationWithAdditionalFile(t *testing.T) {
 	err := LoadConfiguration(
 		cfg,
 		WithConfigYamlDir[testConfig]("./testData/basic"),
-		WithAdditionalConfigFile[testConfig]("anotherconfig.yaml"),
+		WithOverrideConfigFile[testConfig]("anotherconfig.yaml"),
 	)
 	r.NoError(err)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -78,6 +78,38 @@ func TestLoadConfigurationBasic(t *testing.T) {
 	r.Equal("zap", cfg.Nested.Value1)
 }
 
+func TestLoadConfigurationWithAdditionalFile(t *testing.T) {
+	r := require.New(t)
+
+	cfg := &testConfig{}
+	err := LoadConfiguration(
+		cfg,
+		WithConfigYamlDir[testConfig]("./testData/basic"),
+		WithAdditionalConfigFile[testConfig]("anotherconfig.yaml"),
+	)
+	r.NoError(err)
+
+	r.Equal("foo", cfg.Value1)
+	r.Equal("anotherconfig-value-override", cfg.Value2)
+	r.Equal("zap", cfg.Nested.Value1)
+}
+
+func TestLoadConfigurationWithAlternateBaseFileName(t *testing.T) {
+	r := require.New(t)
+
+	cfg := &testConfig{}
+	err := LoadConfiguration(
+		cfg,
+		WithConfigYamlDir[testConfig]("./testData/alternate_base_name"),
+		WithConfigFileBaseName[testConfig]("something"),
+	)
+	r.NoError(err)
+
+	r.Equal("somevalue1", cfg.Value1)
+	r.Equal("somevalue2", cfg.Value2)
+	r.Equal("some-nested-value1", cfg.Nested.Value1)
+}
+
 func TestLoadConfigurationOverlay(t *testing.T) {
 	r := require.New(t)
 

--- a/config/go.mod
+++ b/config/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/go-playground/validator/v10 v10.19.0
+	github.com/google/uuid v1.4.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/config/go.sum
+++ b/config/go.sum
@@ -18,6 +18,8 @@ github.com/go-playground/validator/v10 v10.19.0 h1:ol+5Fu+cSq9JD7SoSqe04GMI92cbn
 github.com/go-playground/validator/v10 v10.19.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/config/testData/alternate_base_name/something.yaml
+++ b/config/testData/alternate_base_name/something.yaml
@@ -1,0 +1,4 @@
+value1: somevalue1
+value2: somevalue2
+nested:
+  value1: some-nested-value1

--- a/config/testData/basic/anotherconfig.yaml
+++ b/config/testData/basic/anotherconfig.yaml
@@ -1,0 +1,1 @@
+value2: anotherconfig-value-override


### PR DESCRIPTION
I will use this in argus to load a new file like:
`app-config.version.yaml`:
```
api:
  version: 0.55.0
```
and then make release-please update `api.version` in that file whenever it runs.

This allows us to still use release-please to keep the version in sync without messing up the main `app-config.yaml`