### PR TITLE
chore: config should be v3

### DIFF
--- a/config/go.mod
+++ b/config/go.mod
@@ -1,4 +1,4 @@
-module github.com/chanzuckerberg/go-misc/config/v2
+module github.com/chanzuckerberg/go-misc/config/v3
 
 go 1.21
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
 	"release-type": "simple",
 	"pull-request-title-pattern": "chore${scope}: release${component} ${version}",
 	"bump-minor-pre-major": true,
+	"separate-pull-requests": true,
 	"prerelease": false,
 	"changelog-types": [
 		{
@@ -21,7 +22,6 @@
 		}
 	],
 	"packages": {
-		".": {},
 		"aws": {
 			"package-name": "aws"
 		},


### PR DESCRIPTION
The suffix needs to match the git release major version which is v3 here https://github.com/chanzuckerberg/go-misc/pull/1099/files