### PR TITLE
chore: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/actions/find-changed-packages/action.yml
+++ b/.github/actions/find-changed-packages/action.yml
@@ -17,7 +17,7 @@ runs:
         filters: |
           changed:
             - added|modified: '**'
-    - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
       id: changedGoPackages
       with:
         script: |

--- a/.github/actions/find-changed-packages/action.yml
+++ b/.github/actions/find-changed-packages/action.yml
@@ -17,7 +17,7 @@ runs:
         filters: |
           changed:
             - added|modified: '**'
-      - uses: actions/github-script@v8
+    - uses: actions/github-script@v8
       id: changedGoPackages
       with:
         script: |

--- a/.github/workflows/autoapprove-dependabot.yml
+++ b/.github/workflows/autoapprove-dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
           private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}

--- a/.github/workflows/aws-mocks.yml
+++ b/.github/workflows/aws-mocks.yml
@@ -9,7 +9,7 @@ jobs:
   upgrade-aws-mocks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -20,7 +20,7 @@ jobs:
           go mod tidy
         working-directory: aws
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}
           branch: actionsbot/upgrade-aws-mocks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       changedPackages: ${{ steps.changedGoPackages.outputs.changedGoPackages }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Find Changed Go Packages
         id: changedGoPackages
         uses: ./.github/actions/find-changed-packages
@@ -27,7 +27,7 @@ jobs:
         gopkg: ${{ fromJson(needs.find-changed-packages.outputs.changedPackages) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version-file: ${{ matrix.gopkg }}/go.mod
@@ -51,7 +51,7 @@ jobs:
         gopkg: ${{ fromJson(needs.find-changed-packages.outputs.changedPackages) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version-file: ${{ matrix.gopkg }}/go.mod

--- a/.github/workflows/mod-update.yml
+++ b/.github/workflows/mod-update.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       changedPackages: ${{ steps.changedGoPackages.outputs.changedGoPackages }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Find Changed Go Packages
         id: changedGoPackages
         uses: ./.github/actions/find-changed-packages
@@ -30,11 +30,11 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
           private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -45,7 +45,7 @@ jobs:
       - name: Update go.mod
         run: go mod tidy
         working-directory: ${{ matrix.gopkg }}
-      - uses: EndBug/add-and-commit@v9
+      - uses: EndBug/add-and-commit@v10
         id: commit_go_mod
         with:
           add: -A

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
       runs-on: ARM64
       steps:
         - name: Generate token
-          uses: actions/create-github-app-token@v1
+          uses: actions/create-github-app-token@v3
           id: generate_token
           with:
             app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}


### PR DESCRIPTION
Created by PatchStorm skill. Upgrades all GitHub Actions runtime references from node20 to node24, and bumps external action dependencies to their node24-compatible versions.