### PR TITLE
chore: upgrade golangci-lint to v2 for go 1.25 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
           go_version_file: ${{ matrix.gopkg }}/go.mod
           level: info
           reporter: github-pr-review
-          golangci_lint_version: v1.64.8 # pin golangci-lint version
-          golangci_lint_flags: "--config=../.golangci.yml --out-format=line-number -v --timeout 5m"
+          golangci_lint_version: v2.12.2 # pin golangci-lint version
+          golangci_lint_flags: "--config=../.golangci.yml -v --timeout 5m"
           workdir: ${{ matrix.gopkg }}
 
   run-tests:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,44 +1,51 @@
+version: "2"
 linters:
   enable:
     - depguard
-    - errcheck
     - errorlint
     - forbidigo
+    - whitespace
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: gopkg.in/yaml.v2
+              desc: please use gopkg.in/yaml.v3 instead
+            - pkg: github.com/pkg/errors
+              desc: please use errors from the standard library instead
+            - pkg: golang.org/x/xerrors
+              desc: please use errors from the standard library instead
+            - pkg: github.com/sirupsen/logrus
+              desc: please use log/slog from the standard library instead
+    forbidigo:
+      forbid:
+        - pattern: ^fmt\.Print.*$
+        - pattern: ^spew\.Dump$
+        - pattern: ^println$
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - forbidigo
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
     - gci
     - gofmt
     - goimports
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-    - whitespace
-
-linters-settings:
-  forbidigo:
-    # These are forbidden in non-test files
-    # If you have mock functions,etc that are meant to be used in tests please add them here
-    forbid:
-      - ^fmt\.Print.*$
-      - ^spew\.Dump$
-      - ^println$
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: gopkg.in/yaml.v2
-            desc: please use gopkg.in/yaml.v3 instead
-          - pkg: github.com/pkg/errors
-            desc: please use errors from the standard library instead
-          - pkg: golang.org/x/xerrors
-            desc: please use errors from the standard library instead
-          - pkg: github.com/sirupsen/logrus
-            desc: please use log/slog from the standard library instead
-
-issues:
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - forbidigo
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Problem

`run-lint (snowflake)` is failing on PR #1171 (and any PR touching the snowflake module). The snowflake `go.mod` directive was bumped to `go 1.25` in #1170 — `apache/thrift` 0.23.0 declares `go 1.25`, so the directive bump is required. The pinned golangci-lint **v1.64.8** is built with go1.24 and refuses to run:

```
can't load config: the Go language version (go1.24) used to build golangci-lint
is lower than the targeted Go version (1.25)
```

golangci-lint exits with status code 3, which makes the reviewdog action throw (rather than the usual filtered-warning behavior).

## Fix

- **v1.64.8 is the final v1 release**, so there is no v1 build for go 1.25. Bump `golangci_lint_version` to **v2.12.2** (built with go1.25+).
- Migrate the shared [.golangci.yml](.golangci.yml) to the v2 schema via `golangci-lint migrate` (default-on linters like errcheck/govet/staticcheck are now implicit; gci/gofmt/goimports moved to `formatters`; v1 behavior preserved via the `legacy` exclusion preset).
- Remove the v1-only `--out-format=line-number` flag — `reviewdog/action-golangci-lint@v2` injects `--output.text.path stdout` automatically for v2.

## Validation

- `golangci-lint config verify` passes on the migrated config.
- `golangci-lint run --config=../.golangci.yml` loads and runs cleanly against the snowflake package (surfaces only pre-existing issues, which reviewdog filters to added lines).

Once merged, release-please will rebase PR #1171 on top of main and its lint check will go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)